### PR TITLE
Jk bm estimated next date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.2.0",
 				"firebase": "^10.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3992,6 +3993,15 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.2.0.tgz",
+			"integrity": "sha512-nEN1z/SEOIWO+8JWIgPDNUkrXmXqNomSh5aiZDNdiaUH/JYqyNeXmEOldtMqAfLicSRiFkapcAIlrUUnPzNaog==",
+			"peerDependencies": {
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.2.0",
 		"firebase": "^10.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -16,6 +16,7 @@ import {
 	isMoreThanADayAgo,
 } from '../utils';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
+import { daysUntilNextPurchase } from '../views/ManageList';
 
 /**
  * A custom hook that subscribes to the user's shopping lists in our Firestore
@@ -199,7 +200,7 @@ export async function updateItem(listPath, itemId) {
 	);
 	const prevEstimate = dateLastPurchased
 		? getDaysBetweenDates(dateNextPurchased, dateLastPurchased)
-		: undefined;
+		: daysUntilNextPurchase;
 	const nextEstimate = calculateEstimate(
 		prevEstimate,
 		daysSinceLastPurchase,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -200,7 +200,7 @@ export async function updateItem(listPath, itemId) {
 	);
 	const prevEstimate = dateLastPurchased
 		? getDaysBetweenDates(dateNextPurchased, dateLastPurchased)
-		: daysUntilNextPurchase;
+		: undefined;
 	const nextEstimate = calculateEstimate(
 		prevEstimate,
 		daysSinceLastPurchase,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -16,7 +16,6 @@ import {
 	isMoreThanADayAgo,
 } from '../utils';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
-import { daysUntilNextPurchase } from '../views/ManageList';
 
 /**
  * A custom hook that subscribes to the user's shopping lists in our Firestore
@@ -200,10 +199,10 @@ export async function updateItem(listPath, itemId) {
 	);
 	const prevEstimate = dateLastPurchased
 		? getDaysBetweenDates(dateNextPurchased, dateLastPurchased)
-		: undefined;
+		: getDaysBetweenDates(dateNextPurchased, dateCreated);
 	const nextEstimate = calculateEstimate(
 		prevEstimate,
-		daysSinceLastPurchase,
+		dateLastPurchased ? daysSinceLastPurchase : prevEstimate,
 		itemTotalPurchases,
 	);
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -189,26 +189,29 @@ export async function updateItem(listPath, itemId) {
 	const itemDocumentRef = doc(listCollectionRef, itemId);
 	const item = await getDoc(itemDocumentRef);
 	const itemTotalPurchases = item.data().totalPurchases;
-	const dateLastPurchased = item.data().dateLastPurchased.toDate();
-	const prevDateNextPurchased = item.data().dateNextPurchased.toDate();
+	const dateLastPurchased = item.data().dateLastPurchased?.toDate();
+	const dateCreated = item.data().dateCreated.toDate();
+	const dateNextPurchased = item.data().dateNextPurchased.toDate();
 	const now = new Date();
-	const daysSinceLastPurchase = getDaysBetweenDates(now, dateLastPurchased); // First buy: 0.
-	const prevEstimate = getDaysBetweenDates(
-		prevDateNextPurchased,
-		dateLastPurchased,
+	const daysSinceLastPurchase = getDaysBetweenDates(
+		now,
+		dateLastPurchased ? dateLastPurchased : dateCreated,
 	);
+	const prevEstimate = dateLastPurchased
+		? getDaysBetweenDates(dateNextPurchased, dateLastPurchased)
+		: undefined;
 	const nextEstimate = calculateEstimate(
 		prevEstimate,
 		daysSinceLastPurchase,
 		itemTotalPurchases,
 	);
-	const dateNextPurchased = getFutureDate(nextEstimate);
 
 	await updateDoc(itemDocumentRef, {
 		dateLastPurchased: now,
-		dateNextPurchased: dateNextPurchased,
+		dateNextPurchased: getFutureDate(nextEstimate),
 		totalPurchases: itemTotalPurchases + 1,
 	});
+
 	return itemDocumentRef;
 }
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -23,12 +23,10 @@ export const isMoreThanADayAgo = (date) => {
 };
 
 /**
- * .
- * @example
- * //
- *
- * @param {Date} date
+ * Returns the number of days elapsed between two dates.
+ * @param {Date} dateFuture
+ * @param {Date} datePast
  */
-export function getDaysBetweenDates(dateFuture, datePast = dateFuture) {
+export function getDaysBetweenDates(dateFuture, datePast) {
 	return Math.ceil((dateFuture.getTime() - datePast.getTime()) / 86400000);
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -21,3 +21,14 @@ export const isMoreThanADayAgo = (date) => {
 	const diff = now - dateInMiliseconds;
 	return ONE_DAY_IN_MILLISECONDS < diff;
 };
+
+/**
+ * .
+ * @example
+ * //
+ *
+ * @param {Date} date
+ */
+export function getDaysBetweenDates(dateFuture, datePast = dateFuture) {
+	return Math.ceil((dateFuture.getTime() - datePast.getTime()) / 86400000);
+}


### PR DESCRIPTION
## Description

For this feature we installed the `@the-collab-lab/shopping-list-utils` dependency so we could import the `calculateEstimate` function, which we use to generate a new `dateNextPurchased` each time an item is marked as purchased.

## Related Issue

Closes #11

## Acceptance Criteria

- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :sparkles: New database feature     |
|  ✓    | :link: Update dependencies |

## Updates

### Before

![image](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/86715948/dfc8bf18-9522-4fc2-835c-a4d6989a2494)

### After

![image](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/86715948/040ae737-76d1-4c95-8eba-74d47b68a023)

## Testing Steps / QA Criteria

- Run `git pull origin jk-bm-estimated-next-date` to pull commit.
- Run `npm install` to update dependencies.
- Create an item.
- Check Firestore's document `dateNextPurchased`.
- Mark item as purchased.
- Check Firestore's document for updated `dateNextPurchased`.