### PR TITLE
Ce ju  dublicate list alert

### DIFF
--- a/src/components/ListForm.jsx
+++ b/src/components/ListForm.jsx
@@ -20,6 +20,7 @@ const ListForm = (props) => {
 	for (let i = 0; i < db.length; i++){
 		if (stringsHaveSameValue(newList,db[i])){
 			setMessage('A List with this name already exists');
+			setNewList('');
 			break;
 		}
 	}

--- a/src/components/ListForm.jsx
+++ b/src/components/ListForm.jsx
@@ -10,17 +10,25 @@ const ListForm = (props) => {
 	const [newList, setNewList] = useState('');
 	const navigate = useNavigate();
 
-	// Idea being that the new list is being stored in a variable
-	// getting the lists from the database as an array and loop through
+	/*
+	Idea being that the new list is being stored in a variable
+	getting the lists from the database as an array and loop through
 
-	//const compare = db;
-	//console.log(createdList, compare)
+	const compare = [db] -- tried to look it up and failed on that;
+	console.log(createdList, compare)
 
-	// compare.forEach((list, i)=>
-	//   if (stringsHaveSameValue(list[i],newList)){
-	// setMessage('There is a list with that name')
-	//   }
-	//)
+	for (let i = 0; i < db.length; i++){
+		if (stringsHaveSameValue(newList,db[i])){
+			setMessage('A List with this name already exists');
+			break;
+		}
+	}
+
+	I am hoping my idea being clear here - obviously if the list name
+	isn't a duplicate, the loop will run from start to finish.
+
+	Maybe there is a nicer way.
+	*/
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();

--- a/src/components/ListForm.jsx
+++ b/src/components/ListForm.jsx
@@ -3,39 +3,28 @@ import { createList } from '../api';
 import { useNavigate } from 'react-router-dom';
 import { inputHasValue } from '../utils/inputValidation';
 import { stringsHaveSameValue } from '../utils/inputValidation';
-//import { db } from '../api/config';
 
 const ListForm = (props) => {
-	const { setMessage, setListPath, userId, userEmail } = props;
+	const { setMessage, setListPath, userId, userEmail, data } = props;
 	const [newList, setNewList] = useState('');
 	const navigate = useNavigate();
 
-	/*
-	Idea being that the new list is being stored in a variable
-	getting the lists from the database as an array and loop through
-
-	const compare = [db] -- tried to look it up and failed on that;
-	console.log(createdList, compare)
-
-	for (let i = 0; i < db.length; i++){
-		if (stringsHaveSameValue(newList,db[i])){
-			setMessage('A List with this name already exists');
-			setNewList('');
-			break;
+	const checkNameNewList = (newList) => {
+		if (data.some((item) => stringsHaveSameValue(newList, item.name))) {
+			return true;
 		}
-	}
-
-	I am hoping my idea being clear here - obviously if the list name
-	isn't a duplicate, the loop will run from start to finish.
-
-	Maybe there is a nicer way.
-	*/
+	};
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();
 
 		if (!inputHasValue(newList)) {
 			setMessage('Please type a list name :)');
+			setNewList('');
+			return;
+		}
+		if (checkNameNewList(newList)) {
+			setMessage('A List with this name already exists');
 			setNewList('');
 			return;
 		}

--- a/src/components/ListForm.jsx
+++ b/src/components/ListForm.jsx
@@ -16,7 +16,11 @@ const ListForm = (props) => {
 	//const compare = db;
 	//console.log(createdList, compare)
 
-	// compare.forEach((list, i)=> stringsHaveSameValue(list[i],newList))
+	// compare.forEach((list, i)=>
+	//   if (stringsHaveSameValue(list[i],newList)){
+	// setMessage('There is a list with that name')
+	//   }
+	//)
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();

--- a/src/components/ListForm.jsx
+++ b/src/components/ListForm.jsx
@@ -2,11 +2,21 @@ import { useState } from 'react';
 import { createList } from '../api';
 import { useNavigate } from 'react-router-dom';
 import { inputHasValue } from '../utils/inputValidation';
+import { stringsHaveSameValue } from '../utils/inputValidation';
+//import { db } from '../api/config';
 
 const ListForm = (props) => {
 	const { setMessage, setListPath, userId, userEmail } = props;
 	const [newList, setNewList] = useState('');
 	const navigate = useNavigate();
+
+	// Idea being that the new list is being stored in a variable
+	// getting the lists from the database as an array and loop through
+
+	//const compare = db;
+	//console.log(createdList, compare)
+
+	// compare.forEach((list, i)=> stringsHaveSameValue(list[i],newList))
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -18,6 +18,7 @@ export function Home({ data, setListPath, userId, userEmail }) {
 					setListPath={setListPath}
 					userId={userId}
 					userEmail={userEmail}
+					data={data}
 				/>
 				{message !== '' && <ErrorMessage errorMessage={message} />}
 			</div>


### PR DESCRIPTION
## Description

The user won't be able to create lists with a repeating name normalised. In this instance, if the user has a list called 'breakfast' and tries to put in 'break fast' it still counts as a repeating name.

## Related Issue

closes #27 

## Acceptance Criteria

[x ] Show an error message if the user tries to submit a new list that is identical to an existing name. For instance, if the list name contains breakfast and the user creates breakfast.
[x] Show an error message if the user tries to submit a new list that matches an existing name with punctuation and casing normalized. For instance, if the list name contains breakfast and the user adds Breakfast or BreakFast, or break fast.


## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :sparkles: New feature     |

## Updates

### Before

If entering a list name that already exists, the user will be sent to the list that is already created

![image](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/99062030/88e233a0-6b9f-401d-9279-f92d9fd6e3fa)

### After

Now if the user enters a name that matches an existing list, the user gets a message

![image](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/99062030/b8fe5726-09cc-4269-8813-71a2edcd4ed3)

## Testing Steps / QA Criteria

git checkout -b ce-ju--dublicate-list-alert
git pull origin ce-ju--dublicate-list-alert
npm start


