### PR TITLE
Improve user navigation 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,7 @@ export function App() {
 	return (
 		<Router>
 			<Routes>
-				<Route path="/" element={<Layout listPath={listPath} />}>
+				<Route path="/" element={<Layout listPath={listPath} lists={lists} />}>
 					<Route
 						index
 						element={

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -27,7 +27,7 @@ export function Home({ data, setListPath, userId, userEmail }) {
 					<h3>Create a new list</h3>
 				</>
 			) : (
-				<h3>Start creating a new list</h3>
+				<h3>Start by creating a list</h3>
 			)}
 
 			<div className="Home__form">

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -9,9 +9,27 @@ export function Home({ data, setListPath, userId, userEmail }) {
 
 	return (
 		<div className="Home">
-			<p>
-				Hello from the home (<code>/</code>) page!
-			</p>
+			{!!data[0] ? (
+				<>
+					<h3>My lists</h3>
+					<ul>
+						{data.map((list, i) => (
+							<SingleList
+								key={i}
+								name={list.name}
+								path={list.path}
+								setListPath={setListPath}
+								userId={userId}
+								userEmail={userEmail}
+							/>
+						))}
+					</ul>
+					<h3>Create a new list</h3>
+				</>
+			) : (
+				<h3>Start creating a new list</h3>
+			)}
+
 			<div className="Home__form">
 				<ListForm
 					setMessage={setMessage}
@@ -21,18 +39,6 @@ export function Home({ data, setListPath, userId, userEmail }) {
 				/>
 				{message !== '' && <ErrorMessage errorMessage={message} />}
 			</div>
-			<ul>
-				{data.map((list, i) => (
-					<SingleList
-						key={i}
-						name={list.name}
-						path={list.path}
-						setListPath={setListPath}
-						userId={userId}
-						userEmail={userEmail}
-					/>
-				))}
-			</ul>
 		</div>
 	);
 }

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -4,7 +4,7 @@ import './Layout.css';
 import { auth } from '../api/config.js';
 import { SignInButton, SignOutButton, useAuth } from '../api/useAuth.jsx';
 
-export function Layout({ listPath }) {
+export function Layout({ lists, listPath }) {
 	const { user } = useAuth();
 
 	return (
@@ -12,23 +12,27 @@ export function Layout({ listPath }) {
 			<div className="Layout">
 				<header className="Layout-header">
 					<h1>Smart shopping list</h1>
-					<p>{user?.displayName ? `Welcome ${user?.displayName}` : null}</p>
-					{!!user ? <SignOutButton /> : <SignInButton />}
-				</header>
-				<main className="Layout-main">
+
 					{!!user ? (
-						<Outlet />
+						<>
+							<p>{`Welcome ${user?.displayName}`}</p>
+							<SignOutButton />
+						</>
 					) : (
-						<h3>Log in to start using the shopping list app</h3>
+						<>
+							<h3>Log in to begin using the shopping list app</h3>
+							<SignInButton />
+						</>
 					)}
-				</main>
+				</header>
+				<main className="Layout-main">{!!user ? <Outlet /> : null}</main>
 				{!!user && (
 					<nav className="Nav">
 						<div className="Nav-container">
 							<NavLink to="/" className="Nav-link">
 								Home
 							</NavLink>
-							{listPath && (
+							{!!listPath && !!lists[0] && (
 								<>
 									<NavLink to={`/list/${listPath}`} className="Nav-link">
 										List
@@ -38,6 +42,7 @@ export function Layout({ listPath }) {
 									</NavLink>
 								</>
 							)}
+							{!!user ? <SignOutButton /> : <SignInButton />}
 						</div>
 					</nav>
 				)}

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -42,7 +42,7 @@ export function Layout({ lists, listPath }) {
 									</NavLink>
 								</>
 							)}
-							{!!user ? <SignOutButton /> : <SignInButton />}
+							<SignOutButton />
 						</div>
 					</nav>
 				)}

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -28,12 +28,16 @@ export function Layout({ listPath }) {
 							<NavLink to="/" className="Nav-link">
 								Home
 							</NavLink>
-							<NavLink to={`/list/${listPath}`} className="Nav-link">
-								List
-							</NavLink>
-							<NavLink to="/manage-list" className="Nav-link">
-								Manage List
-							</NavLink>
+							{listPath && (
+								<>
+									<NavLink to={`/list/${listPath}`} className="Nav-link">
+										List
+									</NavLink>
+									<NavLink to="/manage-list" className="Nav-link">
+										Manage List
+									</NavLink>
+								</>
+							)}
 						</div>
 					</nav>
 				)}

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -16,21 +16,27 @@ export function Layout({ listPath }) {
 					{!!user ? <SignOutButton /> : <SignInButton />}
 				</header>
 				<main className="Layout-main">
-					<Outlet />
+					{!!user ? (
+						<Outlet />
+					) : (
+						<h3>Log in to start using the shopping list app</h3>
+					)}
 				</main>
-				<nav className="Nav">
-					<div className="Nav-container">
-						<NavLink to="/" className="Nav-link">
-							Home
-						</NavLink>
-						<NavLink to={`/list/${listPath}`} className="Nav-link">
-							List
-						</NavLink>
-						<NavLink to="/manage-list" className="Nav-link">
-							Manage List
-						</NavLink>
-					</div>
-				</nav>
+				{!!user && (
+					<nav className="Nav">
+						<div className="Nav-container">
+							<NavLink to="/" className="Nav-link">
+								Home
+							</NavLink>
+							<NavLink to={`/list/${listPath}`} className="Nav-link">
+								List
+							</NavLink>
+							<NavLink to="/manage-list" className="Nav-link">
+								Manage List
+							</NavLink>
+						</div>
+					</nav>
+				)}
 			</div>
 		</>
 	);


### PR DESCRIPTION
## Description

Changes in this PR improve user navigation in the app by making it more intuitive, showing only the links that are relevant for the user in different situations. 

- If the user is not logged in, the navigation bar is not displayed, and a prompt is rendered next to the log-in button to indicate users to log in to start using the app.

- When the user is logged in, links to all the user lists are displayed on the homepage, but the navigation bar is hidden until the user clicks on any list link and the listPath prop is not null. This is done because clicking on the list link in the nav bar before clicking on any of the list links inside the main content will generate a navigation error in the app to "/list/null". 
Additionally, the navigation bar is not displayed while the user does not have any lists yet. Instead, they find a prompt to start creating a list next to the list form.

Lastly, this PR added a logout button in the nav bar, which is rendered next to the navigation links when there is a logged-in user.

## Related Issue

closes #26 

## Acceptance Criteria

- [x] When user is not logged in, they only see a prompt to log in
- [x] when user is not logged in, they do not see in the navigation bar list and manage list
- [x] When the user has no list yet, they do not see in the navigation bar list and manage list 

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :sparkles: New feature     |
|  ✓    | :art:  Enhancement |
|  ✓    | :bug:  Bug fix |


## Updates
### When the user is not logged in
#### Before
<img width="1003" alt="Screenshot 2024-03-21 at 11 23 23" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/8fc038e2-1879-444d-9d9e-d751faa92a2b">


#### After
<img width="853" alt="Screenshot 2024-03-21 at 11 10 14" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/174ddf10-9005-4562-8257-c9fc86588cbb">

### When the user is logged in and don't have any lists yet
#### Before

<img width="1107" alt="Screenshot 2024-03-21 at 11 24 14" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/f75f0c54-f805-47cd-b474-9669d20c47da">

#### After
<img width="1120" alt="Screenshot 2024-03-21 at 11 10 54" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/fb0e3faf-2f69-4fa8-b4f3-9cc58746fe5b">

### When the user is logged in and have lists but the listPath is null (the user haven't navigated to any list yet)
#### Before
<img width="1084" alt="Screenshot 2024-03-21 at 11 23 50" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/311ddb0b-8628-4b48-a119-0ceb4d838ec6">


#### After
<img width="1153" alt="Screenshot 2024-03-21 at 11 10 39" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/2f449acf-133a-4c2e-978f-28b586e7bd8c">

### When the user is logged in and have lists, and listPath is not null
#### Before
<img width="1002" alt="Screenshot 2024-03-21 at 11 24 28" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/882257e3-f34b-4035-b215-48cf1a699011">


#### After


<img width="1121" alt="Screenshot 2024-03-21 at 11 11 12" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/8feca872-f4f6-442e-b2c2-27e5bad37846">


## Testing Steps / QA Criteria
- git checkout -b `issue-15-navigation`
- git pull origin issue-15-navigation
- Log out from the app and observe the changes on the homepage
- To test changes in the navigation bar, you might delete your lists or add a new user who don't have any lists
