### PR TITLE
Fix home hover

### DIFF
--- a/src/components/ListForm.jsx
+++ b/src/components/ListForm.jsx
@@ -75,7 +75,7 @@ const ListForm = (props) => {
 			/>
 			<button
 				type="submit"
-				className="bg-lightPurple text-puurWhite flex justify-center shadow-lg rounded-md transition ease-in-out hover:bg-darkPurple px-4 py-2 gap-6 shrink-0"
+				className="bg-lightPurple text-puurWhite flex justify-center shadow-lg rounded-md transition ease-in-out hover:bg-hoverPurple px-4 py-2 gap-6 shrink-0"
 			>
 				<div>
 					<i className="fa-solid fa-plus"></i>

--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -30,15 +30,15 @@ export function SingleList({ userEmail, name, path, setListPath, userId }) {
 	}
 
 	return (
-		<li className="mb-8 bg-lightPurple w-full text-puurWhite flex justify-end shadow-lg rounded-md transition ease-in-out relative text-lg sm:text-xl md:text-regular">
+		<li className="mb-8 bg-lightPurple w-full text-puurWhite flex justify-end shadow-lg rounded-md transition ease-in-out relative text-lg sm:text-xl md:text-regular hover:bg-hoverPurple">
 			<button
 				onClick={handleClick}
-				className="w-full px-4 py-2 overflow-x-hidden hover:bg-darkPurple rounded-md"
+				className="w-full px-4 py-2 overflow-x-hidden rounded-md"
 			>
 				{name}
 			</button>
 			<button
-				className="rounded-md transition ease-in-out hover:text-alertRed focus:text-alertRed px-4 py-2 absolute right-0 bg-lightPurple hover:bg-darkPurple"
+				className="rounded-md transition ease-in-out hover:text-alertRed focus:text-alertRed px-4 py-2"
 				onClick={() => handleDelete(userId, userEmail, path, name)}
 				aria-label={`Delete ${name} List`}
 				title={`Delete ${name} List`}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,7 @@ export default {
 			offWhite: '#FCFAFA' /* background header & footer */,
 			lightPurple: '#6966A8' /* background buttons & checkout boxes */,
 			alertRed: '#d52c2c' /* alert */,
+			hoverPurple: '#565384' /* transition from lightPurple on hover */,
 		},
 		screens: {
 			sm: '640px',


### PR DESCRIPTION
## Description

This PR implements the styling suggestion made on the [PR #53](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/pull/53#pullrequestreview-1970042942), adding a new Tailwind color variable (hoverPurple), and implementing it on the Home view elements, also updating the background color transition on hover of the lists.

## Acceptance Criteria

- [x] New hoverPurple used for background color transitions in the Home view.
- [x] Hover changes the background color of the whole element.

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :art:  Enhancement |

## Updates

### Before

![image](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/86715948/8e8e36d0-37ee-497c-afd9-962d5c811d4a)

![image](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/86715948/7a8823ac-d30a-4576-86fe-1c3161b99530)

### After

![image](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/86715948/a5b10804-ae75-496c-9e69-5ca9df794cdc)

![image](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/86715948/cfd3a8d6-fd81-482f-99c6-9d739ae84e57)

## Testing Steps / QA Criteria

- `git pull`
- `git checkout fix-home-hover`
- Hovering over the lists in the Home view.