### PR TITLE
Default background color in Layout, input and buttons

### DIFF
--- a/src/components/ListButtons.jsx
+++ b/src/components/ListButtons.jsx
@@ -5,7 +5,7 @@ const ListButtons = (props) => {
 	const buttonVariants = {
 		purple: 'flex items-center justify-center rounded-lg bg-lightPurple',
 		white:
-			'flex items-center justify-center  rounded-lg bg-white border text-darkPurple',
+			'flex items-center justify-center  rounded-lg bg-puurWhite border text-darkPurple',
 	};
 
 	const iconVariants = {

--- a/src/components/SearchList.jsx
+++ b/src/components/SearchList.jsx
@@ -25,7 +25,7 @@ export const SearchList = ({ data, setNewList }) => {
 		<form>
 			<div className="relative flex items-center ">
 				<input
-					className="bg-white border rounded-lg col-span-1 w-full	font-poppins text-base p-5 "
+					className="bg-puurWhite border text-darkPurple rounded-lg col-span-1 w-full	font-poppins text-base p-5 "
 					id="search"
 					type="text"
 					onChange={(e) => handleFiltering(e)}
@@ -36,7 +36,7 @@ export const SearchList = ({ data, setNewList }) => {
 				<button
 					onClick={(e) => resetInput(e)}
 					aria-label="clear the search bar"
-					className="border rounded-sm h-7 px-1  absolute end-5 flex items-center"
+					className="border text-darkPurple rounded-sm h-7 px-1  absolute end-5 flex items-center"
 				>
 					<i className="fa-solid fa-x fa-2xs"></i>
 				</button>

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -12,7 +12,7 @@ export function Layout({ lists, listPath }) {
 	};
 
 	return (
-		<div className="max-w-screen flex flex-col text-poppins min-w-96 ">
+		<div className="max-w-screen flex flex-col text-poppins min-w-96 bg-puurWhite min-h-screen">
 			<NavBar user={user} lists={lists} listPath={listPath} />
 			<main className="w-full lg:pt-16  pb-12 xl:w-9/12  xl:mx-auto">
 				{!!user ? (


### PR DESCRIPTION

## Description
Force a default background color while we don't have a dark palette implemented in the app to avoid incorrect color setup and inconsistencies in different theme settings.

## Acceptance Criteria

- [x] All views and elements default to light mode, regardless of system and browser theme preferences

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :art:  Enhancement |
|  ✓    | :bug:  Bug fix |

## Updates

### Before
#### Homepage
<img width="923" alt="Screenshot 2024-04-02 at 09 44 10" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/01bdd4f9-356c-434d-8c51-eb6c5a39d2ae">
#### List view
<img width="918" alt="Screenshot 2024-04-02 at 09 44 28" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/5489efa1-787d-4d2a-b3bc-c87510860f79">


### After
#### Homepage
<img width="1420" alt="Screenshot 2024-04-02 at 09 43 22" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/94e913d1-5a1d-4077-af3a-96bdd77b892b">
#### List view
<img width="896" alt="Screenshot 2024-04-02 at 09 43 46" src="https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/26d1e893-e176-4a4d-9a1b-0cec9c7de3b5">

## Testing Steps / QA Criteria
- `git pull default-bg-color`
- Navigate the app changing your local color preferences in the browser and in your system settings
