### PR TITLE
Bug fix: Ensure users cannot navigate to and view the content of a deleted list

### DIFF
--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -16,6 +16,7 @@ export function SingleList({ userEmail, name, path, setListPath, userId }) {
 				)
 			) {
 				deleteList(user, email, listPath, listName);
+				setListPath('');
 			}
 			return;
 		}
@@ -25,6 +26,7 @@ export function SingleList({ userEmail, name, path, setListPath, userId }) {
 			)
 		) {
 			deleteList(user, email, listPath, listName);
+			setListPath('');
 		}
 		return;
 	}


### PR DESCRIPTION

## Description

Currently, when a user deletes a list, they can still navigate to the list page and see the deleted list's content.

To prevent this, we need to clear the local storage when a list is deleted, preventing users from accessing deleted lists and their content.

## Acceptance Criteria

- [x] When a list is deleted, users cannot navigate to this list view and see their content anymore.

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :bug:  Bug fix |

## Updates

### Before


https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/1afa7603-a317-473f-a1c4-1209374561e7



### After


https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/91918142/db786834-2fe8-4a29-a2be-44f09dc8782b



## Testing Steps / QA Criteria
- `git pull fix-delete-list-bug`
- test the bug fix by creating and deleting a list
