### PR TITLE
Loading after sign in

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ export function App() {
 	 * This custom hook holds info about the current signed in user.
 	 * Check ./api/useAuth.jsx for its implementation.
 	 */
-	const { user } = useAuth();
+	const { user, isLoadingUser } = useAuth();
 	const userId = user?.uid;
 	const userEmail = user?.email;
 
@@ -45,7 +45,17 @@ export function App() {
 	return (
 		<Router>
 			<Routes>
-				<Route path="/" element={<Layout listPath={listPath} lists={lists} />}>
+				<Route
+					path="/"
+					element={
+						<Layout
+							listPath={listPath}
+							lists={lists}
+							user={user}
+							isLoadingUser={isLoadingUser}
+						/>
+					}
+				>
 					<Route
 						index
 						element={

--- a/src/api/useAuth.jsx
+++ b/src/api/useAuth.jsx
@@ -34,9 +34,12 @@ export const SignOut = () => {
  */
 export const useAuth = () => {
 	const [user, setUser] = useState(null);
+	const [isLoadingUser, setIsLoadingUser] = useState(false);
 
 	useEffect(() => {
+		setIsLoadingUser(true);
 		auth.onAuthStateChanged((user) => {
+			setIsLoadingUser(false);
 			setUser(user);
 			if (user) {
 				addUserToDatabase(user);
@@ -44,5 +47,5 @@ export const useAuth = () => {
 		});
 	}, []);
 
-	return { user };
+	return { user, isLoadingUser };
 };

--- a/src/components/Loading.css
+++ b/src/components/Loading.css
@@ -18,7 +18,7 @@
 .spinner {
 	width: 5rem; /* 1 */
 	padding: 0.5rem; /* 2 */
-	background: var(--color-accent); /* 3 */
+	background: #6966a8; /* 3 */
 
 	aspect-ratio: 1;
 	border-radius: 50%;

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,12 +1,10 @@
 import { Outlet } from 'react-router-dom';
-import { auth } from '../api/config.js';
-import { SignIn, useAuth } from '../api/useAuth.jsx';
+import { SignIn } from '../api/useAuth.jsx';
 import { NavBar } from '../components/NavBar/NavBar.jsx';
 import Groceries from '../assets/groceries.png';
+import Loading from '../components/Loading.jsx';
 
-export function Layout({ lists, listPath }) {
-	const { user } = useAuth();
-
+export function Layout({ lists, listPath, user, isLoadingUser }) {
 	const handleClickSignIn = () => {
 		SignIn();
 	};
@@ -15,7 +13,9 @@ export function Layout({ lists, listPath }) {
 		<div className="w-screen flex flex-col text-poppins min-w-96 bg-puurWhite">
 			<NavBar user={user} lists={lists} listPath={listPath} />
 			<main className="h-screen w-full lg:pt-16 xl:w-9/12  xl:mx-auto">
-				{!!user ? (
+				{isLoadingUser ? (
+					<Loading />
+				) : !!user ? (
 					<Outlet />
 				) : (
 					<div className="flex flex-col justify-items-center	pt-12 lg:justify-between lg:m-20 lg:pt-0 lg:flex-row">


### PR DESCRIPTION
## Description

This PR shows the Loading component after the Google sign in page by conditionally rendering it based on a new state implemented in the useAuth() hook.

## Related Issue

closes #71

## Acceptance Criteria

- [x] After log in, a Loading component is shown until the user data is fetched, transitioning to the appropiate view.

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :sparkles: New feature     |
|  ✓    | :art:  Enhancement |

## Updates

### Before

![before](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/86715948/4acc2e36-7c19-45de-9800-d0b66261319b)

### After

![after](https://github.com/the-collab-lab/tcl-71-smart-shopping-list/assets/86715948/997ea907-b4bc-4f9a-902b-2aaa4b761df8)

## Testing Steps / QA Criteria

- `git pull`
- `git checkout sign-loading`
- Sign in and observe new Loading state.